### PR TITLE
Testing with ph

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is our homespun script for [the CCSO/Ph server](http://en.wikipedia.org/wik
 SomnolCCSO is functional, but currently a little rough around the edges. It's read-only by design--while CCSO does have editing and authentication functionality, none of that is implemented in our script. This is meant to be a simple, easy-to-deploy Python CCSO server for the curious. All database updates are done "offline" by editing the entries.json file in the same folder as the script. A sample entries.json file with some of our own entries is included in this repo.
 
 ## Features
-- Commands: `status`, `siteinfo`, `fields`, `query`, `reload`
+- Commands: `status`, `siteinfo`, `id`, `fields`, `query`, `reload`
     - Most clients (like Netscape, Mosaic, and Lynx) can only send `query` commands, so telnet or a client capable of sending raw CCSO commands is required for the others
     - `reload` (updates database entries and status info from disk) can only be run every 60 seconds by default
 - Reads database entries from JSON and `status`/`siteinfo` data from their respective files

--- a/ccso.py
+++ b/ccso.py
@@ -66,7 +66,7 @@ def reload_db():
     with open('status.txt', 'r') as u:
         for line in u:
             server_status.append(line.rstrip('\n'))
-        server_status.append(nl('200:Ok.'))
+        server_status.append(nl('201:Database ready, read-only.'))
         logger.info('Server status read from status.txt')
     with open('siteinfo.txt', 'r') as i:
         for line in i:

--- a/ccso.py
+++ b/ccso.py
@@ -257,6 +257,9 @@ class PhProtocol(asyncio.Protocol):
                     self.transport.close()
                     logging.info('Client has disconnected')
                     break
+                # This is sent by the PH client after establishing connection
+                elif args[0] in ["id"]:
+                    self.transport.write(to_bytes(nl('200:Ok.')))
                 # If you try to put in anything other than status, fields, reload, or query
                 elif args[0] != '':
                     self.transport.write(to_bytes(nl('514:Unknown command.')))

--- a/status.txt
+++ b/status.txt
@@ -1,3 +1,2 @@
 100:SomnolCCSO v0.2
 100:Serving all your "who are these people" needs since 2024
-201:Database ready, read-only.


### PR DESCRIPTION
Cool server!

I tested it out with the official `ph` client from here: https://github.com/michael-lazar/ccso-nameserver.

When `ph` connects, it immediately sends a few commands. These all need to return success responses or ph will immediately disconnect:

```
id 0
siteinfo
status
siteinfo
```

The `id` command is used to identify the user to the server (it's just the user's UID). This is only for logging purposes, so all you need to do is accept this command and return a 200 status.

I have no idea why `siteinfo` is sent twice. The software is very brittle...

`status` was returning two success codes, a `201` and then a `200`. This confused `ph` and every time I typed a command, it would print the response from the previous command.

With those issues fixed, it works!

```
Launching ph client in interactive mode
Don't forget to specify the server host with '-s hostname'
100:Ph client $Revision: 7.6 $
100:SomnolCCSO v0.2
100:Serving all your "who are these people" needs since 2024
201:Database ready, read-only.
200:Ok.

ph> siteinfo
-200:SomnolCCSO v0.2
-200:mailfield:email
-200:mailbox:email
-200:administrator:mariteaux@somnolescent.net
-200:details:gopher://gopher.somnolescent.net/1/ccso/
200:Ok.
ph> status
100:SomnolCCSO v0.2
100:Serving all your "who are these people" needs since 2024
201:Database ready, read-only.
ph> query name="Cammy"
----------------------------------------
 name: Cammy ('mariteaux')
 sex: Male
 species: European badger, Irish Red-and-White Setter, snow leopard, river otter, Flareon
 universe: Earth
 affiliation: Somnolescent
 discord: mariteaux
 site: http://mariteaux.somnolescent.net, http://cammy.somnolescent.net
 email: mariteaux@somnolescent.net
 projects: Too many to fuckin count
----------------------------------------
ph>
```